### PR TITLE
Fixed Patch BorshDeserialize can cause UB by copying zero sized objects with no safe Copy impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e6cb63579996213e822f6d828b0a47e1d23b1e8708f52d18a6b1af5670dd207"
+dependencies = [
+ "cfg_aliases",
+]
+
+[[package]]
 name = "borsh-derive"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +228,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
@@ -368,12 +383,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-
-[[package]]
 name = "fixed-hash"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,7 +504,7 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 name = "linkdrop"
 version = "0.1.0"
 dependencies = [
- "borsh",
+ "borsh 1.0.0",
  "near-sdk",
 ]
 
@@ -511,7 +520,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de83d74a9241be8cc4eb3055216966b58bf8c463e8e285c0dc553925acdd19fa"
 dependencies = [
- "borsh",
+ "borsh 0.9.3",
  "serde",
 ]
 
@@ -523,7 +532,7 @@ checksum = "b8ecf0b8b31aa7f4e60f629f72213a2617ca4a5f45cd1ae9ed2cf7cecfebdbb7"
 dependencies = [
  "arrayref",
  "blake2",
- "borsh",
+ "borsh 0.9.3",
  "bs58",
  "c2-chacha",
  "curve25519-dalek",
@@ -548,7 +557,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a2ba19282e79a4485a77736b679d276b09870bbf8042a18e0f0ae36347489c5"
 dependencies = [
- "borsh",
+ "borsh 0.9.3",
  "byteorder",
  "bytesize",
  "chrono",
@@ -578,7 +587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb561feb392bb8c4f540256073446e6689af087bf6356e8dddcf75fc279f201f"
 dependencies = [
  "base64 0.11.0",
- "borsh",
+ "borsh 0.9.3",
  "bs58",
  "derive_more",
  "near-account-id",
@@ -617,7 +626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda34e06e28fb9a09ac54efbdc49f0c9308780fc932aaa81c49c493fde974045"
 dependencies = [
  "base64 0.13.0",
- "borsh",
+ "borsh 0.9.3",
  "bs58",
  "near-crypto",
  "near-primitives",
@@ -654,7 +663,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e02faf2bc1f6ef82b965cfe44389808fb5594f7aca4b596766117f4ce74df20"
 dependencies = [
- "borsh",
+ "borsh 0.9.3",
  "near-account-id",
  "near-rpc-error-macro",
  "serde",
@@ -667,7 +676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f024d90451cd3c24d7a0a5cabf3636b192a60eb8e3ff0456f6c18b91152c346d"
 dependencies = [
  "base64 0.13.0",
- "borsh",
+ "borsh 0.9.3",
  "bs58",
  "byteorder",
  "near-account-id",
@@ -677,7 +686,7 @@ dependencies = [
  "near-vm-errors",
  "ripemd",
  "serde",
- "sha2 0.8.1",
+ "sha2 0.10.2",
  "sha3",
 ]
 
@@ -991,18 +1000,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sha2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
 ]
 
 [[package]]


### PR DESCRIPTION

## Description Sumarry :
Affected of project `near/near-linkdrop/` borsh cause undefined behavior when zero-sized-types (ZST) are parsed and the Copy/Clone traits are not implemented/derived. For instance if 1000 instances of a ZST are deserialized, and the ZST is not copy (this can be achieved through a singleton), then accessing/writing to deserialized data will cause a segmentation fault.

**PoC:**
```js
mod singleton {
    use std::sync::atomic::{AtomicBool, Ordering};

    // Important: no Copy or Clone impl
    pub struct Handle(());

    impl Handle {
        pub fn get() -> Self {
            static EXISTS: AtomicBool = AtomicBool::new(false);
            if EXISTS.swap(true, Ordering::Relaxed) {
                panic!("one singleton handle has already been created");
            } else {
                Handle(())
            }
        }

        // Proof of exclusive access to a handle grants exclusive access to some
        // corresponding underlying state. It's guaranteed that at most one
        // handle exists in the entire program so this is sound.
        pub fn access(&mut self) -> &mut State {
            static mut STATE: State = None;
            unsafe { &mut STATE }
        }
    }

    type State = Option<String>;
}

use borsh::BorshDeserialize;
use std::io::Result;

struct Wrap(singleton::Handle);

impl BorshDeserialize for Wrap {
    fn deserialize(_buf: &mut &[u8]) -> Result<Self> {
        Ok(Wrap(singleton::Handle::get()))
    }
}

fn main() {
    let mut x = Vec::<Wrap>::deserialize(&mut &[2, 0, 0, 0][..]).unwrap();
    let (first, rest) = x.split_first_mut().unwrap();
    *first.0.access() = Some("...................".to_owned());
    let s = rest[0].0.access().as_mut().unwrap();
    *first.0.access() = None;
    println!("{}", s);
}
```
```js
 } else if size_of::<T>() == 0 { 
     let mut result = Vec::new(); 
     result.push(T::deserialize(buf)?); 
  
     let p = result.as_mut_ptr(); 
     unsafe { 
         forget(result); 
         let len = len.try_into().map_err(|_| ErrorKind::InvalidInput)?; 
         let result = Vec::from_raw_parts(p, len, len); 
         Ok(result) 
     } 
```