### PR TITLE
fix: Fixed state compatibility due to near_sdk::store and near_sdk::collections not borsh-compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/near/near-linkdrop"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = { version = "5.17.0", features = ["global-contracts"] }
+near-sdk = { version = "5.17.0", features = ["legacy", "global-contracts"] }
 
 [dev-dependencies]
 near-sdk = { version = "5.14", features = ["unit-testing"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ impl LinkDrop {
     #[payable]
     pub fn send(&mut self, public_key: PublicKey) -> Promise {
         assert!(
-            env::attached_deposit() > NearToken::from_yoctonear(1),
+            env::attached_deposit() > NearToken::from_near(0),
             "Attached deposit must be at least 1 yoctoNEAR"
         );
         let value = self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use models::*;
 #[derive(PanicOnDefault)]
 pub struct LinkDrop {
     #[allow(deprecated)]
-    pub accounts: near_sdk::store::UnorderedMap<PublicKey, NearToken>,
+    pub accounts: near_sdk::collections::UnorderedMap<PublicKey, NearToken>,
 }
 
 /// Access key allowance for linkdrop keys.
@@ -32,7 +32,7 @@ impl LinkDrop {
     pub fn new() -> Self {
         Self {
             #[allow(deprecated)]
-            accounts: near_sdk::store::UnorderedMap::new(b"a"),
+            accounts: near_sdk::collections::UnorderedMap::new(b"a"),
         }
     }
 
@@ -46,11 +46,10 @@ impl LinkDrop {
         let value = self
             .accounts
             .get(&public_key)
-            .cloned()
             .unwrap_or(NearToken::from_near(0));
         self.accounts.insert(
-            public_key.clone(),
-            value.saturating_add(env::attached_deposit()),
+            &public_key,
+            &value.saturating_add(env::attached_deposit()),
         );
         Promise::new(env::current_account_id()).add_access_key_allowance(
             public_key,
@@ -235,14 +234,14 @@ impl LinkDrop {
             Promise::new(env::current_account_id()).delete_key(env::signer_account_pk());
         } else {
             // In case of failure, put the amount back.
-            self.accounts.insert(env::signer_account_pk(), amount);
+            self.accounts.insert(&env::signer_account_pk(), &amount);
         }
         creation_succeeded
     }
 
     /// Returns the balance associated with given key.
     pub fn get_key_balance(&self, key: PublicKey) -> NearToken {
-        *self.accounts.get(&key).expect("Key is missing")
+        self.accounts.get(&key).expect("Key is missing")
     }
 
     /// Returns information associated with a given key.
@@ -250,7 +249,7 @@ impl LinkDrop {
     #[handle_result]
     pub fn get_key_information(&self, key: PublicKey) -> Result<KeyInfo, &'static str> {
         match self.accounts.get(&key) {
-            Some(balance) => Ok(KeyInfo { balance: *balance }),
+            Some(balance) => Ok(KeyInfo { balance }),
             None => Err("Key is missing"),
         }
     }
@@ -491,7 +490,7 @@ mod tests {
         // Attempt to recreate the same linkdrop twice
         contract.send(pk.clone());
         assert_eq!(
-            *contract.accounts.get(&pk).unwrap(),
+            contract.accounts.get(&pk).unwrap(),
             deposit
                 .saturating_add(deposit)
                 .saturating_add(NearToken::from_yoctonear(1))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,10 +47,8 @@ impl LinkDrop {
             .accounts
             .get(&public_key)
             .unwrap_or(NearToken::from_near(0));
-        self.accounts.insert(
-            &public_key,
-            &value.saturating_add(env::attached_deposit()),
-        );
+        self.accounts
+            .insert(&public_key, &value.saturating_add(env::attached_deposit()));
         Promise::new(env::current_account_id()).add_access_key_allowance(
             public_key,
             ACCESS_KEY_ALLOWANCE,


### PR DESCRIPTION
I tested it with:

1. deploying the old version of near-linkdrop:

    ```
    near contract download-wasm near save-to-file near.wasm network-config mainnet at-block-height 162445611
    near contract deploy frol15.testnet use-file ./near.wasm with-init-call new json-args {} prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR' network-config testnet sign-with-keychain send
    near contract call-function as-transaction frol15.testnet send json-args '{"public_key": "ed25519:6t61tLxdfhapMi6RaLvAhkMEZ4VVXjWLJthqvfKAe3hJ"}' prepaid-gas '100.0 Tgas' attached-deposit '1.5 NEAR' sign-as frol14.testnet network-config testnet-fastnear sign-with-legacy-keychain send
    ```
2. Checking that it works:

    ```
    near contract call-function as-read-only frol15.testnet get_key_balance json-args '{"key": "ed25519:6t61tLxdfhapMi6RaLvAhkMEZ4VVXjWLJthqvfKAe3hJ"}' network-config testnet-fastnear now
    ```
3. Deploying the fixed version of the contract:

    ```
    near contract deploy frol15.testnet use-file ./target/near/linkdrop.wasm without-init-call network-config testnet sign-with-keychain send
    ```
4. Checking that it still works just fine:

    ```
    near contract call-function as-read-only frol15.testnet get_key_balance json-args '{"key": "ed25519:6t61tLxdfhapMi6RaLvAhkMEZ4VVXjWLJthqvfKAe3hJ"}' network-config testnet-fastnear now
    ```